### PR TITLE
fix(SlackAPI)[NI]: Store slack message's timestamp in the database

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ app.get("/bathrooms/:id", function (req, res) {
 app.put("/bathrooms/:id", function (req, res) {
   var updateDoc = req.body;
   updateDoc.name = BATHROOMS[req.params.id];
-  updateSlackChannel(res, req.params.id, updateDocupdateDoc);
+  updateSlackChannel(res, req.params.id, updateDoc);
 });
 
 function updateDatabase(res, id, updateDoc){

--- a/server.js
+++ b/server.js
@@ -83,51 +83,44 @@ app.get("/bathrooms/:id", function (req, res) {
 });
 app.put("/bathrooms/:id", function (req, res) {
   var updateDoc = req.body;
-  console.log(1, updateDoc)
   updateDoc.name = BATHROOMS[req.params.id];
-  console.log(2, updateDoc)
-  const timestamp = updateSlackChannel(req.params.id, updateDoc.vacant);
-  console.log(3, updateDoc);
-  updateDoc["lastUpdated"] =  timestamp;
-  db.collection(BATHROOMS_COLLECTION).updateOne({ _id: new ObjectID(req.params.id) }, updateDoc, function (err, doc) {
+  updateSlackChannel(res, req.params.id, updateDocupdateDoc);
+});
+
+function updateDatabase(res, id, updateDoc){
+  db.collection(BATHROOMS_COLLECTION).updateOne({ _id: new ObjectID(id) }, updateDoc, function (err, _doc) {
     if (err) {
       handleError(res, err.message, "Failed to update bathroom");
     } else {
       res.status(204).end();
     }
   });
-});
+}
 
-async function updateSlackChannel(id, state) {
+async function updateSlackChannel(res, id, updateDoc) {
   // Get pretty room info
-  let roomName, lastTimestamp;
-  for (var i = 0; i < BATHROOMS.length; i++) {
-    room = BATHROOMS[i];
-    if (Object.keys(room)[0] === id) {
-      roomName = Object.values(room)[0].name;
-      lastTimestamp = Object.values(room)[0].lastUpdated;
-      break;
-    }
-  }
-  // Delete last message by timestamp
-  if (lastTimestamp) {
-    url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + lastTimestamp
-    fetch(url, { method: 'POST' })
-      .catch(error => console.error(error));
-  }
+  const roomName = BATHROOMS[id];
+  const state = updateDoc.vacant;
+
+  // TODO Delete old message
+  // if (lastTimestamp) {
+  //   url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + lastTimestamp
+  //   fetch(url, { method: 'POST' })
+  //     .catch(error => console.error(error));
+  // }
 
   // Post new message
   stateText = state ? "vacant" : "occupied";
   postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + roomName + '%20bathroom%20is%20' + stateText
 
-  let ts = await fetch(postUrl)
+  fetch(postUrl)
     .then(response => response.json())
     .then(data => {
       timestamp = data['message']['ts'];
-      return timestamp
+      updateDoc["lastUpdated"] = timestamp
+      updateDatabase(res, id, updateDoc);
     })
     .catch(error => console.error(error));
-  return ts;
 }
 
 app.delete("/bathrooms/:id", function (req, res) {

--- a/server.js
+++ b/server.js
@@ -96,11 +96,10 @@ function updateSlackChannel(res, id, updateDoc) {
   });
   db_promise.then(result => {
     const timestamp = result.lastUpdated;
-    deleteSlackMessage(timestamp);
-    
+    deletePreviousSlackMessage(timestamp);
     // Post new message
     stateText = updateDoc.vacant ? "vacant" : "occupied";
-    postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + roomName + '%20bathroom%20is%20' + stateText
+    postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + BATHROOM_NAMES[id] + '%20bathroom%20is%20' + stateText
 
     fetch(postUrl)
       .then(response => response.json())
@@ -113,7 +112,7 @@ function updateSlackChannel(res, id, updateDoc) {
     });
 }
 
-function deleteSlackMessage(timestamp){
+function deletePreviousSlackMessage(timestamp){
   url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + timestamp
 
   fetch(url, { method: 'POST' })

--- a/server.js
+++ b/server.js
@@ -97,19 +97,20 @@ function updateSlackChannel(res, id, updateDoc) {
   db_promise.then(result => {
     const timestamp = result.lastUpdated;
     deletePreviousSlackMessage(timestamp);
-    // Post new message
-    stateText = updateDoc.vacant ? "vacant" : "occupied";
-    postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + BATHROOM_NAMES[id] + '%20bathroom%20is%20' + stateText
+  });
 
-    fetch(postUrl)
-      .then(response => response.json())
-      .then(data => {
-        timestamp = data['message']['ts'];
-        updateDoc["lastUpdated"] = timestamp
-        updateDatabase(res, id, updateDoc);
-      })
-      .catch(error => console.error(error));
-    });
+  // Post new message
+  stateText = updateDoc.vacant ? "vacant" : "occupied";
+  postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + BATHROOM_NAMES[id] + '%20bathroom%20is%20' + stateText
+
+  fetch(postUrl)
+    .then(response => response.json())
+    .then(data => {
+      timestamp = data['message']['ts'];
+      updateDoc["lastUpdated"] = timestamp
+      updateDatabase(res, id, updateDoc);
+    })
+    .catch(error => console.error(error));
 }
 
 function deletePreviousSlackMessage(timestamp){

--- a/server.js
+++ b/server.js
@@ -102,6 +102,16 @@ async function updateSlackChannel(res, id, updateDoc) {
   const roomName = BATHROOMS[id];
   const state = updateDoc.vacant;
 
+  var promise = new Promise(function (resolve, reject) {
+    db.collection(BATHROOMS_COLLECTION).findOne({ _id: new ObjectID(id) }, (function (err, result) {
+      console.log(1, result)
+      resolve(result);
+    }))
+  });
+  promise.then(result => {
+    console.log(2, result);
+  });
+
   // TODO Delete old message
   // if (lastTimestamp) {
   //   url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + lastTimestamp

--- a/server.js
+++ b/server.js
@@ -86,7 +86,7 @@ app.put("/bathrooms/:id", function (req, res) {
   console.log(1, updateDoc)
   updateDoc.name = BATHROOMS[req.params.id];
   console.log(2, updateDoc)
-  const timestamp = updateSlackChannel(req.params.id);
+  const timestamp = updateSlackChannel(req.params.id, updateDoc.vacant);
   console.log(3, updateDoc);
   updateDoc["lastUpdated"] =  timestamp;
   db.collection(BATHROOMS_COLLECTION).updateOne({ _id: new ObjectID(req.params.id) }, updateDoc, function (err, doc) {
@@ -98,7 +98,7 @@ app.put("/bathrooms/:id", function (req, res) {
   });
 });
 
-async function updateSlackChannel(id) {
+async function updateSlackChannel(id, state) {
   // Get pretty room info
   let roomName, lastTimestamp;
   for (var i = 0; i < BATHROOMS.length; i++) {

--- a/server.js
+++ b/server.js
@@ -101,7 +101,7 @@ function updateSlackChannel(res, id, updateDoc) {
 
   // Post new message
   stateText = updateDoc.vacant ? "vacant" : "occupied";
-  postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&text=The%20' + BATHROOM_NAMES[id] + '%20bathroom%20is%20' + stateText
+  postUrl = 'https://slack.com/api/chat.postMessage?token=' + process.env.API_TOKEN + '&channel=GGEEVQ5H9&text=The%20' + BATHROOM_NAMES[id] + '%20bathroom%20is%20' + stateText
 
   fetch(postUrl)
     .then(response => response.json())
@@ -114,7 +114,7 @@ function updateSlackChannel(res, id, updateDoc) {
 }
 
 function deletePreviousSlackMessage(timestamp){
-  url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + timestamp
+  url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GGEEVQ5H9&ts=' + timestamp
 
   fetch(url, { method: 'POST' })
   .catch(error => console.error(error));

--- a/server.js
+++ b/server.js
@@ -97,27 +97,22 @@ function updateDatabase(res, id, updateDoc){
   });
 }
 
-async function updateSlackChannel(res, id, updateDoc) {
+function updateSlackChannel(res, id, updateDoc) {
   // Get pretty room info
   const roomName = BATHROOMS[id];
   const state = updateDoc.vacant;
 
-  var promise = new Promise(function (resolve, reject) {
+  const db_promise = new Promise(function (resolve, reject) {
     db.collection(BATHROOMS_COLLECTION).findOne({ _id: new ObjectID(id) }, (function (err, result) {
-      console.log(1, result)
       resolve(result);
     }))
   });
-  promise.then(result => {
-    console.log(2, result);
+  db_promise.then(result => {
+    const timestamp = result.lastUpdated;
+    console.log(1, timestamp);
+    console.log(2, result["lastUpdated"]);
+    deleteSlackMessage(timestamp);
   });
-
-  // TODO Delete old message
-  // if (lastTimestamp) {
-  //   url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + lastTimestamp
-  //   fetch(url, { method: 'POST' })
-  //     .catch(error => console.error(error));
-  // }
 
   // Post new message
   stateText = state ? "vacant" : "occupied";
@@ -131,6 +126,13 @@ async function updateSlackChannel(res, id, updateDoc) {
       updateDatabase(res, id, updateDoc);
     })
     .catch(error => console.error(error));
+}
+
+function deleteSlackMessage(timestamp){
+  url = 'https://slack.com/api/chat.delete?token=' + process.env.API_TOKEN + '&channel=GS52PUQT0&ts=' + timestamp
+
+  fetch(url, { method: 'POST' })
+  .catch(error => console.error(error));
 }
 
 app.delete("/bathrooms/:id", function (req, res) {


### PR DESCRIPTION
Storing the slack message's timestamp in the database.
This way timestamp persists and doesn't get lost if the app is down. Should solve the random double messages issue.